### PR TITLE
Support LIPSedge M3-ToF

### DIFF
--- a/NiCameraMatrix/Makefile
+++ b/NiCameraMatrix/Makefile
@@ -1,0 +1,17 @@
+SRC = ./NiCameraMatrix.cpp
+CPPFLAGS = -Dlinux -I../../Include -std=c++11
+LDFLAGS = -L../../Lib -lOpenNI
+
+# OpenCV
+CPPFLAGS += -I/usr/local/include
+LDFLAGS += -L/usr/local/lib -lopencv_core -lopencv_highgui -lopencv_imgproc
+
+LOCAL_TARGET = NiCameraMatrix
+
+all: $(LOCAL_TARGET)
+
+$(LOCAL_TARGET): $(SRC)
+	$(CXX) $(SRC) $(CPPFLAGS) $(LDFLAGS) -o $@
+
+clean:
+	rm -rf $(LOCAL_TARGET)

--- a/NiCameraMatrix/NiCameraMatrix.cpp
+++ b/NiCameraMatrix/NiCameraMatrix.cpp
@@ -1,0 +1,79 @@
+//
+// NiCameraMatrix.cpp
+//
+// This example demonstrates how to get camera intrinsic matrix by OpenNI API.
+//
+#include <XnOpenNI.h>
+#include <XnCppWrapper.h>
+#include <iostream>
+#include <iomanip>
+
+#define MAX_STR_SIZE 128
+
+enum
+{
+    // Camera
+    LIPS_STREAM_PROPERTY_FOCAL_LENGTH_X     = 200,
+    LIPS_STREAM_PROPERTY_FOCAL_LENGTH_Y     = 201,
+    LIPS_STREAM_PROPERTY_PRINCIPAL_POINT_X  = 202,
+    LIPS_STREAM_PROPERTY_PRINCIPAL_POINT_Y  = 203
+};
+
+using namespace std;
+using namespace xn;
+
+int main( int argc, char* argv[] )
+{
+    Context mContext;
+    mContext.Init();
+
+    DepthGenerator mDepthGen;
+    ImageGenerator mImageGen;
+    XnStatus status;
+    XnDouble fx, fy, cx, cy;
+    XnChar strDepBuff[MAX_STR_SIZE] = {0};
+    XnChar strImgBuff[MAX_STR_SIZE] = {0};
+
+    status = mDepthGen.Create(mContext);
+
+    if ( XN_STATUS_OK == status )
+    {
+        mDepthGen.GetRealProperty("fx", fx);
+        mDepthGen.GetRealProperty("fy", fy);
+        mDepthGen.GetRealProperty("cx", cx);
+        mDepthGen.GetRealProperty("cy", cy);
+
+        sprintf(strDepBuff, "fx=%f, fy=%f, cx=%f, cy=%f\n", fx, fy, cx, cy);
+    } else {
+        cout << "mDepthGen create fails" << endl;
+        return 1;
+    }
+
+    status = mImageGen.Create(mContext);
+
+    if ( XN_STATUS_OK == status )
+    {
+        mImageGen.GetRealProperty("fx", fx);
+        mImageGen.GetRealProperty("fy", fy);
+        mImageGen.GetRealProperty("cx", cx);
+        mImageGen.GetRealProperty("cy", cy);
+
+        sprintf(strImgBuff, "fx=%f, fy=%f, cx=%f, cy=%f\n", fx, fy, cx, cy);
+    } else {
+        cout << "mImageGen create fails" << endl;
+        //return 1;
+    }
+
+    cout << endl;
+    cout << "=== Camera matrix ===" << endl;
+    cout << "[Depth camera]" << endl;
+    cout << strDepBuff << endl;
+    cout << "[Image camera]" << endl;
+    cout << strImgBuff << endl;
+
+    mDepthGen.Release();
+    mImageGen.Release();
+    mContext.Release();
+
+	return 0;
+}

--- a/NiSimpleViewer/NiSimpleViewer.cpp
+++ b/NiSimpleViewer/NiSimpleViewer.cpp
@@ -28,7 +28,7 @@ int main( int argc, char* argv[] )
     while ( true )
     {
         tStart = (double)getTickCount();
-        mContext.WaitAndUpdateAll();
+        mContext.WaitAnyUpdateAll();
 
         DepthMetaData depthData;
         mDepthGen.GetMetaData( depthData );
@@ -37,6 +37,7 @@ int main( int argc, char* argv[] )
         imgDepth.convertTo( img8bitDepth, CV_8U, 255.0 / 5000 );
         sprintf(fpsstr, "%.2f", 1.0 / (((double)getTickCount() - tStart) / getTickFrequency()));
         putText(img8bitDepth, string("FPS:") + fpsstr, Point(5, 20), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(200, 0, 0));
+        namedWindow( "Depth view", CV_WINDOW_NORMAL );
         imshow( "Depth view", img8bitDepth );
 
         ImageMetaData colorData;


### PR DESCRIPTION
1. Use OpenNI API WaitAnyUpdateAll() because M3-ToF is
   single depth camera, thus WaitAndUpdateAll() causes
   infinite waiting for RGB camera update.

2. Allow window resize. M3-ToF is QQQVGA, image is too
   small on screen.

Bugzilla-Id: